### PR TITLE
monotonic impl: use wrapping_sub to properly handle timer rollover

### DIFF
--- a/rtic_v5/monotonic_nrf52/src/monotonic_nrf52.rs
+++ b/rtic_v5/monotonic_nrf52/src/monotonic_nrf52.rs
@@ -45,7 +45,7 @@ impl Instant {
 
     /// Returns the amount of time elapsed from another instant to this one.
     pub fn duration_since(&self, earlier: Instant) -> Duration {
-        let diff = self.inner - earlier.inner;
+        let diff = self.inner.wrapping_sub(earlier.inner);
         assert!(diff >= 0, "second instant is later than self");
         Duration { inner: diff as u32 }
     }

--- a/rtic_v5/monotonic_stm32l0/src/monotonic_stm32l0.rs
+++ b/rtic_v5/monotonic_stm32l0/src/monotonic_stm32l0.rs
@@ -141,7 +141,7 @@ impl Instant {
 
     /// Returns the amount of time elapsed from another instant to this one.
     pub fn duration_since(&self, earlier: Instant) -> Duration {
-        let diff = self.inner - earlier.inner;
+        let diff = self.inner.wrapping_sub(earlier.inner);
         assert!(diff >= 0, "second instant is later than self");
         Duration { inner: diff as u16 }
     }


### PR DESCRIPTION
After the timer value rolls over the newer more recent value will be negative. Calculating the duration_since with an older still positive Instant results in a panic due to subtracting with overflow:

```
22:07:40.180 panicked at 'attempt to subtract with overflow',
src/monotonic_stm32f0.rs:144:20
```

The `monotonic_stm32l0` implementation was tested on my STM32F0 by only changing the HAL. I can't test `monotonic_nrf52`, but I assume it has the same behavior as the STM32.