### PR TITLE
GHA: build caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,27 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+#        borrow from cortex-m-rtic's GHA
+      - name: Cache cargo dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            - ~/.cargo/bin/
+            - ~/.cargo/registry/index/
+            - ~/.cargo/registry/cache/
+            - ~/.cargo/git/db/
+          key: ${{ runner.OS }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.OS }}-cargo-
+      - name: Cache build output dependencies
+        uses: actions/cache@v2
+        with:
+          path: /tmp/build
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.OS }}-build-
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1
@@ -53,7 +74,7 @@ jobs:
         run: rustup target install thumbv6m-none-eabi thumbv7m-none-eabi thumbv7em-none-eabihf
 
       - name: cargo check
-        run: find . -type f -name Cargo.toml -execdir cargo check ';'
+        run: find . -type f -name Cargo.toml -execdir cargo check --target-dir /tmp/build ';'
 
   # Compilation
   build:


### PR DESCRIPTION
This PR introduces build caching to this project.
In theory, this will accelerate all subsequent PRs that don't modify cargo lock files.

It seems the various examples we have are not compatable with cargo workspaces, even if two workspaces (one for v5 and one for v6) are introduced.
As that failed, instead I instructed cargo to use a shared build directory at `/tmp/build`, to simplify the caching action.﻿
 - [x] cache build & cargo dependencies for `check` GHA
 - [x] cache build & cargo dependencies for `build` GHA
 - [x] ~~Fix GHA not detecting build failures such as #22 ?~~

Blocked by #25, #24