### PR TITLE
Replace deprecated spin_loop_hint() with hint::spin_loop()

### DIFF
--- a/rtic_v5/heartbeat_stm32l4/src/main.rs
+++ b/rtic_v5/heartbeat_stm32l4/src/main.rs
@@ -68,7 +68,7 @@ const APP: () = {
     #[idle]
     fn idle(_: idle::Context) -> ! {
         loop {
-            core::sync::atomic::spin_loop_hint();
+            core::hint::spin_loop();
         }
     }
 


### PR DESCRIPTION
Fixes #22 