### PR TITLE
Link to teensy4-rs RTIC examples from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Short list:
 * Toolchain for your microcontroller
 * OpenOCD
 
+## External examples
+
+Some projects maintain RTIC examples in their own repository. Follow these links to find more RTIC examples.
+
+- The [`teensy4-rs` project](https://github.com/mciantyre/teensy4-rs) maintains `RTIC v1.0` examples that run on the Teensy 4.0 and 4.1.
+
 ## License
 
 Licensed under either of


### PR DESCRIPTION
mciantyre/teensy4-rs#97 migrated all of the project's RTIC examples to
RTIC 1.0. This commit adds a link to the project for those seeking more
examples. Closes #8.

teensy4-rs and its associated projects are in flux, so it's easier for
me to maintain the examples when they're separate from the RTIC examples
repo.