### PR TITLE
Add stm32f411 edge counter example

### DIFF
--- a/rtic_v1/stm32f411_edge_counter/.cargo/config
+++ b/rtic_v1/stm32f411_edge_counter/.cargo/config
@@ -1,0 +1,11 @@
+
+[target.thumbv7em-none-eabihf]
+rustflags = [
+  "-C", "link-arg=-Tlink.x",
+]
+
+[build]
+target = "thumbv7em-none-eabihf"
+
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+runner = "cargo embed --chip STM32F411CEUx "

--- a/rtic_v1/stm32f411_edge_counter/.gitignore
+++ b/rtic_v1/stm32f411_edge_counter/.gitignore
@@ -1,0 +1,3 @@
+/target
+**/*.rs.bk
+Cargo.lock

--- a/rtic_v1/stm32f411_edge_counter/Cargo.toml
+++ b/rtic_v1/stm32f411_edge_counter/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "stm32f411-edge-counter"
+version = "0.1.0"
+authors = ["Rafael Bachmann <rafael.bachmann.93@gmail.com"]
+edition = "2021"
+
+[dependencies]
+cortex-m-rtic = "1.0.0"
+systick-monotonic = "1.0.0"
+
+[dependencies.rtt-target]
+version = "0.3.1"
+features = ["cortex-m"]
+
+[dependencies.panic-rtt-target]
+version = "0.1.2"
+features = ["cortex-m"]
+
+[dependencies.stm32f4xx-hal]
+git = "https://github.com/stm32-rs/stm32f4xx-hal.git"
+features = ["stm32f411", "rt", "rtic-monotonic"]

--- a/rtic_v1/stm32f411_edge_counter/memory.x
+++ b/rtic_v1/stm32f411_edge_counter/memory.x
@@ -1,0 +1,11 @@
+MEMORY
+{
+  /* NOTE K = KiBi = 1024 bytes */
+  FLASH : ORIGIN = 0x08000000, LENGTH = 512K 
+  RAM : ORIGIN = 0x20000000, LENGTH = 128K
+}
+
+/* This is where the call stack will be allocated. */
+/* The stack is of the full descending type. */
+/* NOTE Do NOT modify `_stack_start` unless you know what you are doing */
+_stack_start = ORIGIN(RAM) + LENGTH(RAM);

--- a/rtic_v1/stm32f411_edge_counter/src/main.rs
+++ b/rtic_v1/stm32f411_edge_counter/src/main.rs
@@ -1,0 +1,72 @@
+#![deny(unsafe_code)]
+#![no_main]
+#![no_std]
+#![allow(unused_imports)]
+
+use panic_rtt_target as _panic_handler;
+use rtic::app;
+
+#[app(device = stm32f4xx_hal::pac, peripherals = true, dispatchers = [SPI1])]
+mod app {
+    use core::sync::atomic::{AtomicUsize, Ordering};
+    use rtt_target::{rprintln, rtt_init_print};
+    use stm32f4xx_hal::{
+        gpio::{gpioa::PA0, gpioc::PC6, Alternate, Edge, Input, Output, Pin, PullUp, PushPull},
+        prelude::*,
+    };
+    use systick_monotonic::{fugit::Duration, Systick};
+
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    #[shared]
+    struct Shared {}
+
+    #[local]
+    struct Local {
+        led: Pin<Output<PushPull>, 'C', 13>,
+        pin: Pin<Input<PullUp>, 'A', 0>,
+    }
+
+    #[monotonic(binds = SysTick, default = true)]
+    type Tonic = Systick<1000>;
+
+    #[init]
+    fn init(mut ctx: init::Context) -> (Shared, Local, init::Monotonics) {
+        rtt_init_print!();
+        rprintln!("init");
+
+        let rcc = ctx.device.RCC.constrain();
+        let _clocks = rcc.cfgr.sysclk(48.mhz()).freeze();
+
+        let gpioc = ctx.device.GPIOC.split();
+        let led = gpioc.pc13.into_push_pull_output();
+
+        let gpioa = ctx.device.GPIOA.split();
+        let mut pin = gpioa.pa0.into_pull_up_input();
+        let mut sys_cfg = ctx.device.SYSCFG.constrain();
+        pin.make_interrupt_source(&mut sys_cfg);
+        pin.enable_interrupt(&mut ctx.device.EXTI);
+        pin.trigger_on_edge(&mut ctx.device.EXTI, Edge::Falling);
+
+        let mono = Systick::new(ctx.core.SYST, 48_000_000);
+
+        blink::spawn().ok();
+
+        (Shared {}, Local { pin, led }, init::Monotonics(mono))
+    }
+
+    #[task(local = [led], priority = 4)]
+    fn blink(ctx: blink::Context) {
+        let count = COUNTER.swap(0, Ordering::SeqCst);
+        rprintln!("{}", count);
+        ctx.local.led.toggle();
+        blink::spawn_after(Duration::<u64, 1, 1000>::from_ticks(1000)).ok();
+    }
+
+    #[task(binds = EXTI0, local = [pin])]
+    fn on_exti(ctx: on_exti::Context) {
+        ctx.local.pin.clear_interrupt_pending_bit();
+        rprintln!("incrementing");
+        COUNTER.fetch_add(1, Ordering::SeqCst);
+    }
+}

--- a/rtic_v1/stm32f411_edge_counter/src/main.rs
+++ b/rtic_v1/stm32f411_edge_counter/src/main.rs
@@ -36,7 +36,7 @@ mod app {
         rprintln!("init");
 
         let rcc = ctx.device.RCC.constrain();
-        let _clocks = rcc.cfgr.sysclk(48.mhz()).freeze();
+        let _clocks = rcc.cfgr.sysclk(48.MHz()).freeze();
 
         let gpioc = ctx.device.GPIOC.split();
         let led = gpioc.pc13.into_push_pull_output();


### PR DESCRIPTION
This example shows using systick monotonic, EXTI input, and atomic usize
outside of shared/local resources.