### PR TITLE
add dependabot dependency version update config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  # list all projects here
+  - package-ecosystem: "cargo"
+    directory: "/rtic_v0.5/nrf52_monotonic"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/rtic_v0.5/stm32f0_hid_mouse"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/rtic_v0.5/stm32f1_bluepill_blinky"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/rtic_v0.5/stm32f3_blinky"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/rtic_v0.5/stm32l0_monotonic"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/rtic_v0.5/stm32l4_heartbeat"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/rtic_v1/nrf52_monotonic"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/rtic_v1/stm32f1_bluepill_blinky"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/rtic_v1/stm32f3_blinky"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/rtic_v1/stm32f411_edge_counter"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/rtic_v1/stm32f4_pwm_monitor"
+    schedule:
+      interval: "weekly"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Short list:
 * Toolchain for your microcontroller
 * OpenOCD
 
+## Contributing
+New examples are always welcome!
+
+When contributing a new example you must make sure to also add it to `.github/dependabot.yml`.
+
 ## External examples
 
 Some projects maintain RTIC examples in their own repository. Follow these links to find more RTIC examples.


### PR DESCRIPTION
this enables the [dependabot dependency version update][]. this means that dependabot will weekly check if there are updates available and will then raise PRs with these updates (if they can be applied in an automated way). this helps in ensuring that the dependencies are kept up to date.

it's important that new projects are also added to the config, otherwise they won't be covered by this.
i'm not aware of any way to tell dependabot that it should just look for `Cargo.toml` / `Cargo.lock` on its own.

this also means that existing PRs for new examples should not be merged before this PR is merged so that they can be rebased and the config updated in them (alternatively, if they're merged first then this PR should be updated accordingly).

this solves rtic-rs/rtic-examples#44

[dependabot dependency version update]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates